### PR TITLE
[Fix] Fixed extensive Svelte condition blocks

### DIFF
--- a/odyssey/client/src/Giveaways/MyGiveaways.svelte
+++ b/odyssey/client/src/Giveaways/MyGiveaways.svelte
@@ -101,7 +101,7 @@
 					<h3>{giveaway.text}</h3>
 				</div>
 				
-				{#if giveaway.is_open == true}
+				{#if giveaway.is_open}
 
 					<p>Number of contestants: </p>
 

--- a/odyssey/client/src/Giveaways/UserGiveaways.svelte
+++ b/odyssey/client/src/Giveaways/UserGiveaways.svelte
@@ -88,7 +88,7 @@
 
 		{#if i < loadedGiveaways}
 
-			{#if giveaway.is_open == true}
+			{#if giveaway.is_open}
 
 				<div class='giveaway-box'>
 					{#if giveaway.canView}
@@ -99,7 +99,7 @@
 							<h3>{giveaway.text}</h3>
 						</div>
 						
-						{#if giveaway.hasJoined == false}
+						{#if !giveaway.hasJoined}
 							<button on:click={async () => await joinGiveaway(giveaway._id.$oid)}>Join</button>
 						{:else}
 							<p>You have already joined this giveaway!</p>

--- a/odyssey/client/src/Surveys/MySurveys.svelte
+++ b/odyssey/client/src/Surveys/MySurveys.svelte
@@ -101,7 +101,7 @@
 					<h3>{survey.text}</h3>
 				</div>
 
-				{#if survey.is_open == true}
+				{#if survey.is_open}
 					
 					{#await getVotesOnSurvey(survey._id.$oid) then votes}
 
@@ -139,7 +139,7 @@
 
 				{:else}
 
-						<p>Winning option: {survey.winner}</p>
+					<p>Winning option: {survey.winner}</p>
 
 				{/if}
 

--- a/odyssey/client/src/Surveys/UserSurveys.svelte
+++ b/odyssey/client/src/Surveys/UserSurveys.svelte
@@ -111,7 +111,7 @@
 		
 		{#if i < loadedSurveys}
 
-			{#if survey.is_open == true}
+			{#if survey.is_open}
 
 				<div class='survey-box'>
 					{#if survey.canView}
@@ -124,7 +124,7 @@
 								<h3>{survey.text}</h3>
 							</div>
 							
-							{#if survey.hasVoted == false}
+							{#if !survey.hasVoted}
 
 								{#each survey.options as option, i}
 									<p>{option}</p>
@@ -165,7 +165,7 @@
 
 						{/await}
 
-					{:else if survey.is_open == true}
+					{:else if survey.is_open}
 
 						<div class="cant-view-survey-container">
 							<img class="survey-image-cant-view" src={"/images/" + user.username + "/" + survey.image_path}>


### PR DESCRIPTION
Continuation of [this discussion](https://github.com/ogi02/Odyssey/pull/27#discussion_r431906854)

> HTML doesn't have a way of expressing logic, like conditionals and loops. Svelte does. - [Svelte](https://svelte.dev/tutorial/if-blocks)